### PR TITLE
query_parameters may already been present in url

### DIFF
--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -135,7 +135,11 @@ class HttpClient
     protected function buildUrlQuery($url, $parameters = [])
     {
         if (!empty($parameters)) {
-            $url .= '?' . \http_build_query($parameters);
+            if (false !== strpos($url, '?') {
+                $url .= '&' . \http_build_query($parameters);
+            } else {
+                $url .= '?' . \http_build_query($parameters);
+            }
         }
 
         return $url;


### PR DESCRIPTION
Fix concatenation chars if url already contains a '?'
Eg: /?rest_route=/ 
when using php -S debug mode
Query parameters should be added using '&'